### PR TITLE
Fixed "ReferenceError: error is not defined"

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Microsoft Rewards Bot",
-  "version": "2.24.1.2",
+  "version": "2.24.1.3",
   "icons": {
     "16": "img/bingRwLogo@1x.png",
     "24": "img/bingRwLogo@1.5x.png",

--- a/src/status/DailyRewardStatus.js
+++ b/src/status/DailyRewardStatus.js
@@ -102,7 +102,7 @@ class DailyRewardStatus {
             if (ex.name == 'TypeError') {
                 throw new FetchFailedException('DailyRewardStatus::_awaitFetchPromise', ex, 'Are we redirected? You probably haven\'t logged in yet.');
             }
-            if (error.name == 'AbortError') {
+            if (ex.name == 'AbortError') {
                 throw new FetchFailedException('DailyRewardStatus::_awaitFetchPromise', ex, 'Fetch timed out. Do you have internet connection? Otherwise, perhaps MSR server is down.');
             }
             throw ex;


### PR DESCRIPTION
Repeatedly received the error "ReferenceError: error is not defined" which made the chrome extension unusable.