### PR TITLE
Add the form parameter

### DIFF
--- a/src/quest/searchQuest.js
+++ b/src/quest/searchQuest.js
@@ -160,7 +160,7 @@ class SearchQuest {
             this._googleTrend_.nextPCWord :
             this._googleTrend_.nextMBWord;
 
-        return `https://www.bing.com/search?q=${word}`;
+        return `https://www.bing.com/search?q=${word}&form=QBRE`;
     }
 
     _isCurrentSearchCompleted() {


### PR DESCRIPTION
Bing now requires the form parameter to be present and valid to get points from the search.

The form parameter value used is "QBRE" and is obtained when you initiate a search from the search box of another search.

This should fix: #132, #142, and #144.